### PR TITLE
グラフの表示調整

### DIFF
--- a/app.js
+++ b/app.js
@@ -464,9 +464,11 @@ co(function* () {
         console.log('#######################################################################');
         console.log(outputText);
         console.log('#######################################################################');
-        let chd = 't:' + [...results.values()].map((d) => d.mean).join('|');
+        let means = [...results.values()].map((d) => d.mean);
+        let maxScore = Math.max(...means);
+        let chd = 't:' + means.map(m => m / maxScore * 99).join('|');
         let chdl = [...results.keys()].join('|');
-        let imgUrl = encodeURI(`https://image-charts.com/chart?cht=bhg&chs=400x150&chco=F56991,FF9F80,FFC48C,D1F2A5,EFFAB4,F0E68C&chxt=y&chxs=0,000000,0,0,_&chd=${chd}&chdl=${chdl}`);
+        let imgUrl = encodeURI(`https://image-charts.com/chart?cht=bhg&chs=400x150&chco=F56991,FF9F80,FFC48C,D1F2A5,EFFAB4,F0E68C,D7EEFF&chxt=y&chxs=0,000000,0,0,_&chdlp=b&chd=${chd}&chdl=${chdl}`);
         postToSlack(SLACK_CHANNEL, '```' + outputText + '```', {username:'本日のベンチマーク結果', attachments:[{fallback:outputText,image_url:imgUrl}]});
 
     } finally {


### PR DESCRIPTION
- ベンチマーク結果のグラフが短く表示されるようになっていたので対応
- 4.0と3.0.15の凡例色が被っていたので変更

 修正前
![image](https://image-charts.com/chart?cht=bhg&chs=400x150&chco=F56991,FF9F80,FFC48C,D1F2A5,EFFAB4,F0E68C&chxt=y&chxs=0,000000,0,0,_&chdlp=b&chd=t:26.55%7C26.19%7C26.46%7C12.01%7C13.86%7C13.88%7C11.44&chdl=4.0%7C4.0.1%7C4.0.0%7C3.1%7C3.0%7C3.0.16%7C3.0.15)

修正後
![image](https://image-charts.com/chart?cht=bhg&chs=400x150&chco=F56991,FF9F80,FFC48C,D1F2A5,EFFAB4,F0E68C,D7EEFF&chxt=y&chxs=0,000000,0,0,_&chdlp=b&chd=t:99|97.65762711864407|98.66440677966102|44.78305084745762|51.68135593220339|51.75593220338984|42.657627118644065&chdl=4.0%7C4.0.1%7C4.0.0%7C3.1%7C3.0%7C3.0.16%7C3.0.15)